### PR TITLE
Add network field to metadata

### DIFF
--- a/src/protocols/gwmp/hpr_gwmp_worker.erl
+++ b/src/protocols/gwmp/hpr_gwmp_worker.erl
@@ -238,6 +238,7 @@ packet_up_to_push_data(Up, GatewayTime, GatewayLocation) ->
     Name = erlang:list_to_binary(hpr_utils:gateway_name(PubKeyBin)),
 
     BaseMeta = #{
+        network => <<"helium_iot">>,
         gateway_id => B58,
         gateway_name => Name,
         regi => hpr_packet_up:region(Up)


### PR DESCRIPTION
Ref https://github.com/helium/helium-packet-router/issues/285

In the metadata for a gateway/hotspot that is sent to ChirpStack, explicitly state that this packet comes from the Helium IoT network. This would help services on the other side of ChirpStack know for sure if the packet was received by Helium, without having to guess from the other metadata fields.